### PR TITLE
Update @zitadel/vue local path

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "format": "prettier --write src/"
   },
   "dependencies": {
-    "@zitadel/vue": "link:./lib",
+    "@zitadel/vue": "file:./lib",
     "vue": "^3.3.11",
     "vue-router": "^4.2.5"
   },


### PR DESCRIPTION
Resolves the following error:
```
❯ npm install
npm ERR! code EUNSUPPORTEDPROTOCOL
npm ERR! Unsupported URL Type "link:": link:./lib
```

This is a very minor change I needed to make on a first install. Two other minor things:
- `lib/package.json` refers to files under `dist` which is only created after running `npm build` of course. 
- The [Vue example guide](https://zitadel.com/docs/examples/login/vue#vue-setup) refers to `npm` commands, but it looks like yarn is preferred here in the repo. 
---
Thanks so much for all the well-done implementation examples btw! I've been following the python ones as well 🐾