### PR TITLE
receive roles as array or object

### DIFF
--- a/lib/src/zitadelAuth.ts
+++ b/lib/src/zitadelAuth.ts
@@ -52,7 +52,13 @@ export function createZITADELAuth(
             if (!roles) {
                 return false
             }
-            return roles.find(r => r[role])
+            
+            if (Array.isArray(roles)) {
+                return roles.find(r => r[role]);
+            } else {
+                return Object.keys(roles).some(key => key === role);
+            }
+
         }
     }
 }


### PR DESCRIPTION
this is to resolve
https://github.com/zitadel/zitadel-vue/issues/48

although it's better to investigate the root cause of why the roles type is not consistent, I believe this can be an acceptable solution to bypass the broken build until a full investigation is done.