### PR TITLE
chore: replace deprecated labels with issue types in templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Report errors and problems
 title: ''
-labels: bug
+type: bug
 assignees: ''
 ---
 

--- a/.github/ISSUE_TEMPLATE/documentation-issue.md
+++ b/.github/ISSUE_TEMPLATE/documentation-issue.md
@@ -2,7 +2,7 @@
 name: Documentation Issue
 about: Missing, misleading or incomplete documentation issues
 title: ''
-labels: docs
+labels: area/docs
 assignees: ''
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Ideas for new features and improvements
 title: ''
-labels: enhancement
+type: enhancement
 assignees: ''
 ---
 


### PR DESCRIPTION
## Description

The org is migrating from label-based issue classification to GitHub Issue Types. Issue templates that hardcode `labels:` would silently re-add those labels every time an issue is opened, blocking the cleanup. The `docs` label is also being renamed to `area/docs`.

This PR updates the issue templates:

- `.github/ISSUE_TEMPLATE/bug_report.md` — `labels: bug` → `type: bug`
- `.github/ISSUE_TEMPLATE/feature_request.md` — `labels: enhancement` → `type: enhancement`
- `.github/ISSUE_TEMPLATE/documentation-issue.md` — `labels: docs` → `labels: area/docs`

No other fields were touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MA7kgVw1fjMW32K7FyPASQ)_