### PR TITLE
chore: assign task type to documentation issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation-issue.md
+++ b/.github/ISSUE_TEMPLATE/documentation-issue.md
@@ -3,6 +3,7 @@ name: Documentation Issue
 about: Missing, misleading or incomplete documentation issues
 title: ''
 labels: area/docs
+type: task
 assignees: ''
 ---
 


### PR DESCRIPTION
## Description

Follow-up to #176. Per review feedback (zitadel/terraform-provider-zitadel#421), documentation issues should carry the `task` issue type in addition to the `area/docs` label. #176 was already merged without the type, so this PR adds it.

- `.github/ISSUE_TEMPLATE/documentation-issue.md` — add `type: task` (keeps the `area/docs` label)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MA7kgVw1fjMW32K7FyPASQ)_